### PR TITLE
Close ZipFile after extraction of files

### DIFF
--- a/plugin/src/main/groovy/org/paleozogt/gradle/zip/SymUnzip.groovy
+++ b/plugin/src/main/groovy/org/paleozogt/gradle/zip/SymUnzip.groovy
@@ -104,27 +104,31 @@ class SymUnzip extends AbstractCopyTask {
 
             protected void explodeZip(FileCopyDetails fileDetails, File target) {
                 ZipFile zipFile= new ZipFile(fileDetails.getFile());
-
-                // TODO: for-each?
-                Enumeration entries= zipFile.getEntries();
-                while (entries.hasMoreElements()) {
-                    ZipArchiveEntry entry=(ZipArchiveEntry)entries.nextElement();
-                    File entryFile= new File(target, entry.getName());
-                    entryFile.getParentFile().mkdirs();
-                    getLogger().debug("zip entry {} mode={} symlink={}", entry, entry.getUnixMode(), entry.isUnixSymlink());
-                    if (entry.isUnixSymlink()) {
-                        String linkEntry= getEntryContents(zipFile, entry);
-                        File linkEntryFile= new File(linkEntry);
-                        Files.createSymbolicLink(entryFile.toPath(), linkEntryFile.toPath());
-                    } else if (entry.isDirectory()) {
-                        entryFile.mkdir();
-                        getFileSystem().chmod(entryFile, getEntryMode(entry));
-                    } else {
-                        FileOutputStream outputStream = new FileOutputStream(entryFile);
-                        IOUtils.copy(zipFile.getInputStream(entry), outputStream);
-                        outputStream.close();
-                        getFileSystem().chmod(entryFile, getEntryMode(entry));
-                    }
+                try {
+                  // TODO: for-each?
+                  Enumeration entries= zipFile.getEntries();
+                  while (entries.hasMoreElements()) {
+                      ZipArchiveEntry entry=(ZipArchiveEntry)entries.nextElement();
+                      File entryFile= new File(target, entry.getName());
+                      entryFile.getParentFile().mkdirs();
+                      getLogger().debug("zip entry {} mode={} symlink={}", entry, entry.getUnixMode(), entry.isUnixSymlink());
+                      if (entry.isUnixSymlink()) {
+                          String linkEntry= getEntryContents(zipFile, entry);
+                          File linkEntryFile= new File(linkEntry);
+                          Files.createSymbolicLink(entryFile.toPath(), linkEntryFile.toPath());
+                      } else if (entry.isDirectory()) {
+                          entryFile.mkdir();
+                          getFileSystem().chmod(entryFile, getEntryMode(entry));
+                      } else {
+                          FileOutputStream outputStream = new FileOutputStream(entryFile);
+                          IOUtils.copy(zipFile.getInputStream(entry), outputStream);
+                          outputStream.close();
+                          getFileSystem().chmod(entryFile, getEntryMode(entry));
+                      }
+                  }
+                }
+                finally {
+                  ZipFile.closeQuietly( zipFile )
                 }
             }
 

--- a/plugin/src/main/groovy/org/paleozogt/gradle/zip/SymUnzip.groovy
+++ b/plugin/src/main/groovy/org/paleozogt/gradle/zip/SymUnzip.groovy
@@ -120,7 +120,9 @@ class SymUnzip extends AbstractCopyTask {
                         entryFile.mkdir();
                         getFileSystem().chmod(entryFile, getEntryMode(entry));
                     } else {
-                        IOUtils.copy(zipFile.getInputStream(entry), new FileOutputStream(entryFile));
+                        FileOutputStream outputStream = new FileOutputStream(entryFile);
+                        IOUtils.copy(zipFile.getInputStream(entry), outputStream);
+                        outputStream.close();
                         getFileSystem().chmod(entryFile, getEntryMode(entry));
                     }
                 }


### PR DESCRIPTION
Hi,
during usage of you symzip plugin I found also that ZipFile is not closed after finish. So I prepared this pull request.
This is what reports gradle during usage:
Cleaning up unclosed ZipFile for archive /var/lib/jenkins/workspace/.gradle/caches/modules-2/files-2.1/curl/7.26.0-SNAPSHOT/919a2373ab9e09399ddd7779001a4194d7e60b0/curl-7.26.0-SNAPSHOT.zip
Cleaning up unclosed ZipFile for archive /var/lib/jenkins/workspace/.gradle/caches/modules-2/files-2.1/openssl/1.0.1o-SNAPSHOT/3460e4837f3fc19ea9f376e0f5b716b8f0efbafa/openssl-1.0.1o-SNAPSHOT.zip