### PR TITLE
Modify "makeTestData" to handle existing directory

### DIFF
--- a/plugin/src/test/resources/test-build/build.gradle
+++ b/plugin/src/test/resources/test-build/build.gradle
@@ -42,6 +42,12 @@ task makeTestData() {
     }
 }
 
+task cleanBuildDirectory(type: Delete) {
+    delete("$buildDir")
+}
+
+makeTestData.dependsOn(cleanBuildDirectory)
+
 task runSymZip(type:SymZip, dependsOn:makeTestData) {
     from file(makeTestData.outputs.files.first())
     archiveName "sym-zip.zip"


### PR DESCRIPTION
The test `org.paleozogt.gradle.zip.SymZipPluginTest.sampleBuildTest` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. The test fails when it tries to build a directory which is already existing.

The changes ensure that the existing build directory is properly cleaned before executing `makeTestData`. 

Please let me know if you want to discuss further about the changes.